### PR TITLE
Danieljohnson/issue51

### DIFF
--- a/dsi/core.py
+++ b/dsi/core.py
@@ -107,14 +107,15 @@ class Terminal():
 
     def add_external_python_module(self, mod_type, mod_name, mod_path):
         """
-        Adds a given external, meaning not from the DSI repo, Python module to the module_collection.
+        Adds a given external, meaning not from the DSI repo, Python module to the module_collection
 
         Afterwards, load_module can be used to load a DSI module from the added Python module.
-        Note: mod_type is needed because each Python module should only implement plugins or drivers.
-        
+        Note: mod_type is needed because each Python module should only implement plugins or drivers
+
         For example,
         term = Terminal()
-        term.add_external_python_module('plugin', 'my_python_file', '/the/path/to/my_python_file.py')
+        term.add_external_python_module('plugin', 'my_python_file',
+                                        '/the/path/to/my_python_file.py')
         term.load_module('plugin', 'MyPlugin', 'consumer')
         term.list_loaded_modules() # includes MyPlugin
         """

--- a/dsi/plugins/metadata.py
+++ b/dsi/plugins/metadata.py
@@ -63,6 +63,8 @@ class StructuredMetadata(Plugin):
             row_dict = {k: v for k, v in zip(
                 self.output_collector.keys(), row)}
             self.validation_model.model_validate(row_dict)
+        elif len(row) != self.column_cnt:
+            raise RuntimeError("Incorrect length of row was given")
 
         for key, row_elem in zip(self.output_collector.keys(), row):
             self.output_collector[key].append(row_elem)

--- a/dsi/plugins/plugin_models.py
+++ b/dsi/plugins/plugin_models.py
@@ -1,0 +1,34 @@
+"""
+A collection of pydantic models for Plugin schema validation
+"""
+
+from pydantic import BaseModel, create_model
+
+
+def create_dynamic_model(name: str, col_names: list[str],
+                         col_types: list[type], base=None) -> BaseModel:
+    """
+    Creates a pydantic model at runtime with given name, column names
+    and types, and an optional base model to extend.
+
+    This is useful for when column names are not known until
+    they are retrieved at runtime.
+    """
+    name_type_dict = {k: (v, ...) for k, v in zip(col_names, col_types)}
+    return create_model(name, __base__=base, **name_type_dict)
+
+
+class EnvironmentModel(BaseModel):
+    uid: int
+    effective_gid: int
+    moniker: str
+    gid_list: list[int]
+
+
+class HostnameModel(EnvironmentModel):
+    hostname: str
+
+
+class GitInfoModel(EnvironmentModel):
+    git_remote: str
+    git_commit: str

--- a/dsi/plugins/tests/test_env.py
+++ b/dsi/plugins/tests/test_env.py
@@ -97,5 +97,5 @@ def test_git_plugin_infos_are_str():
     plug = GitInfo(git_repo_path=root)
     plug.add_row()
 
-    assert type(plug.output_collector["git-remote"][0]) == str
-    assert type(plug.output_collector["git-commit"][0]) == str
+    assert type(plug.output_collector["git_remote"][0]) == str
+    assert type(plug.output_collector["git_commit"][0]) == str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,6 @@ classifiers=[
 ]
 dependencies = [
 	"gitpython",
-  "pyarrow"
+  "pyarrow",
+  "pydantic"
 ]


### PR DESCRIPTION
The way I integrated this was the following:

* Plugins can optionally provide a pydantic model to set_schema
* If a model was provided, before adding each row the schema will be verified and throw an exception if invalid

I implemented models for the current set of plugins. Some of which can be defined statically like [this](https://github.com/lanl/dsi/blob/1da0c4282471209805da0e3b801a58627a26f772/dsi/plugins/plugin_models.py#L28), and some of which have to be defined dynamically like [this](https://github.com/lanl/dsi/blob/1da0c4282471209805da0e3b801a58627a26f772/dsi/plugins/env.py#L77).

Before the only schema checking was that the correct number of columns were provided, but with pydantic we are able to check for correct types as well as validation within types (i.e. pydantic PositiveInt type).