### PR TITLE
Add module unloading + test

### DIFF
--- a/dsi/core.py
+++ b/dsi/core.py
@@ -109,6 +109,10 @@ class Terminal():
         """
         Unloads a DSI module from the active_modules collection
         """
+        if self.transload_lock and mod_type == 'plugin':
+            print(
+                'Plugin  module unloading is prohibited after transload. No action taken.')
+            return
         for i, mod in enumerate(self.active_modules[mod_function]):
             if mod.__class__.__name__ == mod_name:
                 self.active_modules[mod_function].pop(i)

--- a/dsi/core.py
+++ b/dsi/core.py
@@ -115,7 +115,8 @@ class Terminal():
                 print("{} {} {} unloaded successfully.".format(
                     mod_name, mod_type, mod_function))
                 return
-        print("{} {} {} could not be found in active_modules. No action taken.")
+        print("{} {} {} could not be found in active_modules. No action taken.".format(
+            mod_name, mod_type, mod_function))
 
     def add_external_python_module(self, mod_type, mod_name, mod_path):
         """

--- a/dsi/core.py
+++ b/dsi/core.py
@@ -105,13 +105,25 @@ class Terminal():
             print('Hint: Did you declare your Plugin/Driver in the Terminal Global vars?')
             raise NotImplementedError
 
+    def unload_module(self, mod_type, mod_name, mod_function):
+        """
+        Unloads a DSI module from the active_modules collection
+        """
+        for i, mod in enumerate(self.active_modules[mod_function]):
+            if mod.__class__.__name__ == mod_name:
+                self.active_modules[mod_function].pop(i)
+                print("{} {} {} unloaded successfully.".format(
+                    mod_name, mod_type, mod_function))
+                return
+        print("{} {} {} could not be found in active_modules. No action taken.")
+
     def add_external_python_module(self, mod_type, mod_name, mod_path):
         """
         Adds a given external, meaning not from the DSI repo, Python module to the module_collection.
 
         Afterwards, load_module can be used to load a DSI module from the added Python module.
         Note: mod_type is needed because each Python module should only implement plugins or drivers.
-        
+
         For example,
         term = Terminal()
         term.add_external_python_module('plugin', 'my_python_file', '/the/path/to/my_python_file.py')

--- a/dsi/tests/test_core.py
+++ b/dsi/tests/test_core.py
@@ -6,3 +6,12 @@ def test_terminal_module_getter():
     plugins = a.list_available_modules('plugin')
     drivers = a.list_available_modules('driver')
     assert len(plugins) > 0 and len(drivers) > 0
+
+
+def test_unload_module():
+    a = Terminal()
+    print(a.list_loaded_modules())
+    a.load_module('plugin', 'GitInfo', 'producer')
+    assert len(a.list_loaded_modules()['producer']) == 1
+    a.unload_module('plugin', 'GitInfo', 'producer')
+    assert len(a.list_loaded_modules()['producer']) == 0

--- a/dsi/tests/test_core.py
+++ b/dsi/tests/test_core.py
@@ -14,3 +14,11 @@ def test_unload_module():
     assert len(a.list_loaded_modules()['producer']) == 1
     a.unload_module('plugin', 'GitInfo', 'producer')
     assert len(a.list_loaded_modules()['producer']) == 0
+
+
+def test_unload_after_transload_fails():
+    a = Terminal()
+    a.load_module('plugin', 'Hostname', 'producer')
+    a.transload()
+    a.unload_module('plugin', 'Hostname', 'producer')
+    assert len(a.list_loaded_modules()['producer']) == 1

--- a/dsi/tests/test_core.py
+++ b/dsi/tests/test_core.py
@@ -10,7 +10,6 @@ def test_terminal_module_getter():
 
 def test_unload_module():
     a = Terminal()
-    print(a.list_loaded_modules())
     a.load_module('plugin', 'GitInfo', 'producer')
     assert len(a.list_loaded_modules()['producer']) == 1
     a.unload_module('plugin', 'GitInfo', 'producer')


### PR DESCRIPTION
According to issue #45, I added a simple module unloading function that searches the active_modules collection for the given plugin and removes it. 