### PR TITLE
serialize SystemKernel info

### DIFF
--- a/dsi/plugins/env.py
+++ b/dsi/plugins/env.py
@@ -5,6 +5,7 @@ import subprocess
 from getpass import getuser
 from git import Repo
 import git.exc
+from json import dumps
 
 from dsi.plugins.metadata import StructuredMetadata
 
@@ -145,12 +146,11 @@ class SystemKernel(Environment):
     def __init__(self) -> None:
         """Initialize SystemKernel with inital provenance info."""
         super().__init__()
-        self.prov_info = self.get_prov_info()
+        self.column_names = ["kernel_info"]
 
     def pack_header(self) -> None:
         """Set schema with keys of prov_info."""
-        column_names = list(self.posix_info.keys()) + \
-            list(self.prov_info.keys())
+        column_names = list(self.posix_info.keys()) + self.column_names
         self.set_schema(column_names)
 
     def add_row(self) -> None:
@@ -158,19 +158,19 @@ class SystemKernel(Environment):
         if not self.schema_is_set():
             self.pack_header()
 
-        pairs = self.get_prov_info()
-        self.add_to_output(list(self.posix_info.values()) +
-                           list(pairs.values()))
+        blob = self.get_kernel_info()
+        self.add_to_output(list(self.posix_info.values()) + [blob])
 
-    def get_prov_info(self) -> dict:
+    def get_kernel_info(self) -> str:
         """Collect and return the different categories of provenance info."""
-        prov_info = {}
-        prov_info.update(self.get_kernel_version())
-        prov_info.update(self.get_kernel_ct_config())
-        prov_info.update(self.get_kernel_bt_config())
-        prov_info.update(self.get_kernel_rt_config())
-        prov_info.update(self.get_kernel_mod_config())
-        return prov_info
+        kernel_info = {}
+        kernel_info.update(self.get_kernel_version())
+        kernel_info.update(self.get_kernel_ct_config())
+        kernel_info.update(self.get_kernel_bt_config())
+        kernel_info.update(self.get_kernel_rt_config())
+        kernel_info.update(self.get_kernel_mod_config())
+        blob = dumps(kernel_info)
+        return blob
 
     def get_kernel_version(self) -> dict:
         """Kernel version is obtained by the "uname -r" command, returns it in a dict. """

--- a/dsi/plugins/tests/test_env.py
+++ b/dsi/plugins/tests/test_env.py
@@ -2,6 +2,7 @@ import collections
 
 from dsi.plugins.env import Hostname, SystemKernel, Bueno, GitInfo
 import git
+from json import loads
 
 
 def get_git_root(path):
@@ -35,12 +36,12 @@ def test_hostname_plugin_row_shape():
             assert len(col) == row_shape == row_cnt
 
 
-def test_envprov_plugin_type():
+def test_systemkernel_plugin_type():
     plug = SystemKernel()
     assert type(plug.output_collector) == collections.OrderedDict
 
 
-def test_envprov_plugin_adds_rows():
+def test_systemkernel_plugin_adds_rows():
     plug = SystemKernel()
     plug.add_row()
     plug.add_row()
@@ -48,8 +49,19 @@ def test_envprov_plugin_adds_rows():
     for key, val in plug.output_collector.items():
         assert len(val) == 2
 
-    # should def have more than 100 columns
-    assert len(plug.output_collector.keys()) > 100
+    # 1 SystemKernel column + 4 inherited Env cols
+    assert len(plug.output_collector.keys()) == 5
+
+
+def test_systemkernel_plugin_blob_is_big():
+    plug = SystemKernel()
+    plug.add_row()
+
+    blob = plug.output_collector["kernel_info"][0]
+    info_dict = loads(blob)
+
+    # dict should have more than 1000 (~7000) keys
+    assert len(info_dict.keys()) > 1000
 
 
 def test_bueno_plugin_type():


### PR DESCRIPTION
SystemKernel was already populating a dictionary when adding a row, so here I propose serializing that dictionary into a JSON string so a user could recover it if needed.