### PR TITLE
Documentation and code re-stucture

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -10,3 +10,12 @@ Plugins connect data-producing applications to DSI middleware. Plugins have "pro
 .. automodule:: dsi.plugins.env
    :members:
 
+Optional Plugin Type Enforcement
+==================================
+
+Plugins take data in an arbitrary format, and transform it into metadata which is queriable in DSI. Plugins may enforce types, but they are not required to enforce types. Plugin type enforcement can be static, like the Hostname default plugin. Plugin type enforcement can also be dynamic, like the Bueno default plugin.
+
+
+.. automodule:: dsi.plugins.plugin_models
+   :members:
+


### PR DESCRIPTION
We will use this PR to coordinate the code and documentation re-structure that we've been discussing over the past few weeks.

During the re-structuring period, documentation will reflect progress on _this_ branch. Ordinarily the documentation reflects code on the main branch or a release tag. We will change back to that behavior when this PR is merged into main.

Daniel, feel free to PR into this branch, or push commits to it directly. When you push commits, please also push documentation to the public facing website so we can all see what's proposed.