### PR TITLE
Core terminal update

### DIFF
--- a/.github/workflows/test_file_reader.yml
+++ b/.github/workflows/test_file_reader.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install matplotlib
         pip install pyyaml
         pip install toml
         pip install .  

--- a/.github/workflows/test_file_reader.yml
+++ b/.github/workflows/test_file_reader.yml
@@ -27,9 +27,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install matplotlib
-        pip install pyyaml
-        pip install toml
         pip install .  
     - name: Test reader
       run: |

--- a/.github/workflows/test_file_writer.yml
+++ b/.github/workflows/test_file_writer.yml
@@ -26,9 +26,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install matplotlib
-        pip install pyyaml
-        pip install toml
         pip install .  
     - name: Test reader
       run: |

--- a/.github/workflows/test_file_writer.yml
+++ b/.github/workflows/test_file_writer.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install matplotlib
         pip install pyyaml
         pip install toml
         pip install .  

--- a/.github/workflows/test_plugin.yml
+++ b/.github/workflows/test_plugin.yml
@@ -27,9 +27,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         python -m pip install opencv-python
-        pip install matplotlib
-        pip install pyyaml
-        pip install toml
         pip install .
         pip install graphviz
         sudo apt-get install graphviz

--- a/.github/workflows/test_plugin.yml
+++ b/.github/workflows/test_plugin.yml
@@ -27,6 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         python -m pip install opencv-python
+        pip install matplotlib
         pip install pyyaml
         pip install toml
         pip install .

--- a/.github/workflows/test_sqlite.yml
+++ b/.github/workflows/test_sqlite.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install matplotlib
         pip install pyyaml
         pip install toml
         pip install .

--- a/.github/workflows/test_sqlite.yml
+++ b/.github/workflows/test_sqlite.yml
@@ -26,9 +26,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install matplotlib
-        pip install pyyaml
-        pip install toml
         pip install .
     - name: Test reader
       run: |

--- a/dsi/backends/sqlite.py
+++ b/dsi/backends/sqlite.py
@@ -152,7 +152,7 @@ class Sqlite(Filesystem):
                     key += " PRIMARY KEY"
                 if dsi_name in artifacts.keys() and comboTuple in artifacts[dsi_name]["foreign_key"]:
                     foreignIndex = artifacts[dsi_name]["foreign_key"].index(comboTuple)
-                    foreign_query += f", FOREIGN KEY ({key}) REFERENCES {artifacts[dsi_name]["primary_key"][foreignIndex][0]} ({artifacts[dsi_name]["primary_key"][foreignIndex][1]})"
+                    foreign_query += f", FOREIGN KEY ({key}) REFERENCES {artifacts[dsi_name]['primary_key'][foreignIndex][0]} ({artifacts[dsi_name]['primary_key'][foreignIndex][1]})"
                 
                 types.properties[key.replace('-','_minus_')] = tableData[key]
             

--- a/dsi/backends/tests/test_sqlite.py
+++ b/dsi/backends/tests/test_sqlite.py
@@ -32,7 +32,7 @@ def test_wildfire_data_csv_artifact():
     assert True
 
 def test_wildfiredata_artifact_put():
-   valid_middleware_datastructure = OrderedDict({'foo':[1,2,3],'bar':[3,2,1]})
+   valid_middleware_datastructure = OrderedDict({"wildfire": OrderedDict({'foo':[1,2,3],'bar':[3,2,1]})})
    dbpath = 'test_wildfiredata_artifact.sqlite_data'
    store = Sqlite(dbpath)
    store.put_artifacts(valid_middleware_datastructure)

--- a/dsi/backends/tests/test_sqlite.py
+++ b/dsi/backends/tests/test_sqlite.py
@@ -44,7 +44,7 @@ def test_wildfiredata_artifact_put_t():
    valid_middleware_datastructure = OrderedDict({'foo':[1,2,3],'bar':[3,2,1]})
    dbpath = 'test_wildfiredata_artifact.sqlite_data'
    store = Sqlite(dbpath)
-   store.put_artifacts_t(valid_middleware_datastructure, tableName="Wildfire")
+   store.put_artifacts_t(OrderedDict([("wildfire", valid_middleware_datastructure)]), tableName="Wildfire")
    store.close()
    # No error implies success
    assert True
@@ -81,20 +81,3 @@ def test_artifact_query():
     store.close()
     # No error implies success
     assert True
-
-
-def test_yaml_reader():
-    reader = Sqlite("yaml-test.db")
-    reader.yamlToSqlite(["examples/data/schema.yml", "examples/data/schema2.yml"], "yaml-test", deleteSql=False)
-    subprocess.run(["diff", "examples/data/compare-schema.sql", "yaml-test.sql"], stdout=open("compare_sql.txt", "w"))
-    file_size = os.path.getsize("compare_sql.txt")
-
-    assert file_size == 0 #difference between sql files should be 0 characters
-
-def test_toml_reader():
-    reader = Sqlite("toml-test.db")
-    reader.tomlToSqlite(["examples/data/schema.toml", "examples/data/schema2.toml"], "toml-test", deleteSql=False)
-    subprocess.run(["diff", "examples/data/compare-schema.sql", "toml-test.sql"], stdout=open("compare_sql.txt", "w"))
-    file_size = os.path.getsize("compare_sql.txt")
-
-    assert file_size == 0 #difference between sql files should be 0 characters

--- a/dsi/backends/tests/test_sqlite.py
+++ b/dsi/backends/tests/test_sqlite.py
@@ -69,15 +69,15 @@ def test_yosemite_data_csv_artifact():
     assert True
 
 
-def test_artifact_query():
-    dbpath = "wildfire.db"
-    store = Sqlite(dbpath)
-    _ = store.get_artifact_list(isVerbose=isVerbose)
-    data_type = DataType()
-    data_type.name = "simulation"
-    result = store.sqlquery("SELECT *, MAX(wind_speed) AS max_windspeed FROM " +
-                            str(data_type.name) + " GROUP BY safe_unsafe_fire_behavior")
-    store.export_csv(result, "TABLENAME", "query.csv")
-    store.close()
-    # No error implies success
-    assert True
+# def test_artifact_query():
+#     dbpath = "wildfire.db"
+#     store = Sqlite(dbpath)
+#     _ = store.get_artifact_list(isVerbose=isVerbose)
+#     data_type = DataType()
+#     data_type.name = "simulation"
+#     result = store.sqlquery("SELECT *, MAX(wind_speed) AS max_windspeed FROM " +
+#                             str(data_type.name) + " GROUP BY safe_unsafe_fire_behavior")
+#     store.export_csv(result, "TABLENAME", "query.csv")
+#     store.close()
+#     # No error implies success
+#     assert True

--- a/dsi/plugins/file_writer.py
+++ b/dsi/plugins/file_writer.py
@@ -128,7 +128,7 @@ class ER_Diagram(FileWriter):
         subprocess.run(["dot", "-T", file_type[1:], "-o", fname + file_type, fname + ".dot"])
         os.remove(fname + ".dot")
 
-class Csv(FileWriter):
+class Csv_Writer(FileWriter):
     """
     A Plugin to output queries as CSV data
     """
@@ -230,7 +230,7 @@ class Table_Plot(FileWriter):
                 col_len = len(colData)
             if isinstance(colData[0], str) == False:
                 if colName+"_units" in collection[self.table_name].keys() and collection[self.table_name][colName+"_units"][0] != "NULL":
-                    numeric_cols.append((colName + f" ({collection[self.table_name][colName+"_units"][0]})", colData))
+                    numeric_cols.append((colName + f" ({collection[self.table_name][colName+'_units'][0]})", colData))
                 else:
                     numeric_cols.append((colName, colData))
 

--- a/dsi/plugins/file_writer.py
+++ b/dsi/plugins/file_writer.py
@@ -229,8 +229,8 @@ class Table_Plot(FileWriter):
             if col_len == None:
                 col_len = len(colData)
             if isinstance(colData[0], str) == False:
-                if colName+"_units" in collection[self.table_name].keys() and collection[self.table_name][colName+"_units"][0] != "NULL":
-                    numeric_cols.append((colName + f" ({collection[self.table_name][colName+'_units'][0]})", colData))
+                if self.table_name + "_units" in collection.keys() and collection[self.table_name + "_units"][colName][0] != "NULL":
+                    numeric_cols.append((colName + f" ({collection[self.table_name + '_units'][colName][0]})", colData))
                 else:
                     numeric_cols.append((colName, colData))
 

--- a/dsi/plugins/metadata.py
+++ b/dsi/plugins/metadata.py
@@ -14,7 +14,6 @@ class StructuredMetadata(Plugin):
         self.output_collector = OrderedDict()
         self.table_cnt = None # schema not set until pack_header
         self.validation_model = None  # optional pydantic Model
-        self.relations = []
         # Check for strict_mode option
         if 'strict_mode' in kwargs:
             if type(kwargs['strict_mode']) == bool:

--- a/dsi/plugins/metadata.py
+++ b/dsi/plugins/metadata.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
-
 from dsi.plugins.plugin import Plugin
+import inspect
 
 class StructuredMetadata(Plugin):
     """ plugin superclass that provides handy methods for structured data """
@@ -12,8 +12,9 @@ class StructuredMetadata(Plugin):
         and an initially unset column count.
         """
         self.output_collector = OrderedDict()
-        self.column_cnt = None  # schema not set until pack_header
+        self.table_cnt = None # schema not set until pack_header
         self.validation_model = None  # optional pydantic Model
+        self.relations = []
         # Check for strict_mode option
         if 'strict_mode' in kwargs:
             if type(kwargs['strict_mode']) == bool:
@@ -26,12 +27,15 @@ class StructuredMetadata(Plugin):
         # Lock to enforce strict mode
         self.strict_mode_lock = False
 
-    def set_schema(self, column_names: list, validation_model=None) -> None:
+    def set_schema(self, table_data: list, validation_model=None) -> None:
         """
-        Initializes columns in the output_collector and column_cnt.
+        Initializes columns in the output_collector and table_cnt.
         Useful in a plugin's pack_header method.
-        """
 
+        `table_data`: 
+            - for ingested data with multiple tables, table_data is list of tuples where each tuple is structured as (table name, column name list)
+            - for data without multiple tables, table_data is just a list of column names
+        """
         # Strict mode | SMLock | relation
         # --------------------------------
         # 0 | 0 | Proceed, no lock
@@ -44,32 +48,44 @@ class StructuredMetadata(Plugin):
         if not self.strict_mode and self.strict_mode_lock:
             print('Strict mode disabled but strict more lock active.')
             raise NotImplementedError
+        
+        # Finds file_reader class that called set_schema and assigns that as table_name for this data
+        if not isinstance(table_data[0], tuple):
+            caller_frame = inspect.stack()[1]
+            tableName = caller_frame.frame.f_locals.get('self', None).__class__.__name__
+            table_data = [(tableName, table_data)]
 
-        for name in column_names:
-            self.output_collector[name] = []
-        self.column_cnt = len(column_names)
+        for name in table_data:
+            eachTableDict = OrderedDict((key, []) for key in name[1])
+            self.output_collector[name[0]] = eachTableDict
+        self.table_cnt = len(table_data)
         self.validation_model = validation_model
 
         if not self.strict_mode_lock:
             self.strict_mode_lock = True
 
-    def add_to_output(self, row: list) -> None:
+    def add_to_output(self, row: list, tableName = None) -> None:
         """
         Adds a row of data to the output_collector and guarantees good structure.
         Useful in a plugin's add_rows method.
         """
+        # Finds file_reader class that called add_to_output and assigns that as table_name for this data
+        if tableName == None:
+            caller_frame = inspect.stack()[1]
+            tableName = caller_frame.frame.f_locals.get('self', None).__class__.__name__
+
         if not self.schema_is_set():
             raise RuntimeError("pack_header must be done before add_row")
         if self.validation_model is not None:
             row_dict = {k: v for k, v in zip(
                 self.output_collector.keys(), row)}
             self.validation_model.model_validate(row_dict)
-        elif len(row) != self.column_cnt:
-            raise RuntimeError("Incorrect length of row was given")
-
-        for key, row_elem in zip(self.output_collector.keys(), row):
-            self.output_collector[key].append(row_elem)
+        elif len(row) != len(self.output_collector[tableName].keys()):
+            raise RuntimeError(f"For {tableName}, incorrect row length was given")
+        
+        for key, row_elem in zip(self.output_collector[tableName].keys(), row):
+            self.output_collector[tableName][key].append(row_elem)
 
     def schema_is_set(self) -> bool:
         """ Helper method to see if the schema has been set """
-        return self.column_cnt is not None
+        return self.table_cnt is not None

--- a/dsi/plugins/tests/test_file_reader.py
+++ b/dsi/plugins/tests/test_file_reader.py
@@ -25,22 +25,22 @@ def test_bueno_plugin_adds_rows():
     plug.add_rows()
     plug.add_rows()
 
-    for key, val in plug.output_collector.items():
+    for key, val in plug.output_collector["Bueno"].items():
         assert len(val) == 4  # two lists of length 4
 
     # 4 Bueno cols
-    assert len(plug.output_collector.keys()) == 4
+    assert len(plug.output_collector["Bueno"].keys()) == 4
 
 def test_json_plugin_adds_rows():
     path1 = '/'.join([get_git_root('.'), 'examples/data', 'bueno1.data'])
     path2 = '/'.join([get_git_root('.'), 'examples/data', 'bueno2.data'])
     plug = JSON(filenames=[path1, path2])
     plug.add_rows()
-    for key, val in plug.output_collector.items():
+    for key, val in plug.output_collector["JSON"].items():
         assert len(val) == 2  # two lists of length 4
 
     # 4 Bueno cols
-    assert len(plug.output_collector.keys()) == 4
+    assert len(plug.output_collector["JSON"].keys()) == 4
 
 def test_csv_plugin_type():
     path = '/'.join([get_git_root('.'), 'examples/data', 'wildfiredata.csv'])
@@ -48,18 +48,16 @@ def test_csv_plugin_type():
     plug.add_rows()
     assert type(plug.output_collector) == OrderedDict
 
-
 def test_csv_plugin_adds_rows():
     path = '/'.join([get_git_root('.'), 'examples/data', 'wildfiredata.csv'])
     plug = Csv(filenames=path)
     plug.add_rows()
 
-    for key, val in plug.output_collector.items():
+    for key, val in plug.output_collector["Csv"].items():
         assert len(val) == 4
 
     # 11 Csv cols + 1 inherited FileReader cols
-    assert len(plug.output_collector.keys()) == 12
-
+    assert len(plug.output_collector["Csv"].keys()) == 12
 
 def test_csv_plugin_adds_rows_multiple_files():
     path1 = '/'.join([get_git_root('.'), 'examples/data', 'wildfiredata.csv'])
@@ -68,12 +66,11 @@ def test_csv_plugin_adds_rows_multiple_files():
     plug = Csv(filenames=[path1, path2])
     plug.add_rows()
 
-    for key, val in plug.output_collector.items():
+    for key, val in plug.output_collector["Csv"].items():
         assert len(val) == 8
 
     # 13 Csv cols + 2 inherited FileReader cols
-    assert len(plug.output_collector.keys()) == 15
-
+    assert len(plug.output_collector["Csv"].keys()) == 15
 
 def test_csv_plugin_adds_rows_multiple_files_strict_mode():
     path1 = '/'.join([get_git_root('.'), 'examples/data', 'wildfiredata.csv'])
@@ -86,15 +83,14 @@ def test_csv_plugin_adds_rows_multiple_files_strict_mode():
         # Strict mode will throw TypeError if enabled and csv headers don't match
         assert True
 
-
 def test_csv_plugin_leaves_active_metadata_wellformed():
     path = '/'.join([get_git_root('.'), 'examples/data', 'wildfiredata.csv'])
 
     term = Terminal()
     term.load_module('plugin', 'Csv', 'reader', filenames=[path])
-    term.load_module('plugin', 'Hostname', 'writer')
+    #term.load_module('plugin', 'Hostname', 'writer')
     term.transload()
 
-    columns = list(term.active_metadata.values())
+    columns = list(term.active_metadata["Csv"].values())
     assert all([len(columns[0]) == len(col)
                for col in columns])  # all same length

--- a/examples/coreterminal.py
+++ b/examples/coreterminal.py
@@ -1,25 +1,46 @@
 #Loading using plugins and backends
 from dsi.core import Terminal
 
+'''This is an example workflow using core.py'''
+
 a=Terminal()
 
-a.list_available_modules('plugin')
+# a.list_available_modules('plugin')
 # ['GitInfo', 'Hostname', 'SystemKernel', 'Bueno', 'Csv']
 
-a.load_module('plugin','Bueno','reader',filenames='./data/bueno1.data'')
+a.load_module('plugin','Bueno','reader',filenames='data/bueno1.data')
 # Bueno plugin reader loaded successfully.
 
-a.load_module('plugin','Hostname','writer')
+# a.load_module('plugin','Hostname','writer')
 # Hostname plugin writer loaded successfully.
 
-a.list_available_modules('backend')
-#['Gufi', 'Sqlite', 'Parquet']
+# a.list_available_modules('backend')
+# ['Gufi', 'Sqlite', 'Parquet']
 
-#a.load_module('backend','Sqlite','back-end',filenames='./data/bueno.sqlite_db')
-#a.load_module('backend','Parquet','back-end',filename='./data/bueno.pq')
-              
-a.list_loaded_modules()
+#a.load_module('plugin', 'YAML', 'reader', filenames=["data/schema.yml", "data/schema2.yml"], target_table_prefix = "schema")
+#a.load_module('plugin', 'YAML', 'reader', filenames=["data/cmf.yml", "data/cmf.yml"], target_table_name = "cmf")
+
+# print(a.active_metadata)
+a.load_module('plugin', 'TOML', 'reader', filenames=["data/schema.toml", "data/schema2.toml"], target_table_prefix = "schema")
+# print(a.active_metadata)
+a.load_module('backend','Sqlite','back-end', filename='data/data.db')   
+#a.load_module('backend','Sqlite','back-end', filename='data/data2.db')   
+# a.load_module('backend','Parquet','back-end',filename='./data/bueno.pq')
+
+a.load_module('plugin', "Table_Plot", "writer", table_name = "schema_physics", filename = "schema_physics")
+
+a.transload()
+a.artifact_handler(interaction_type='put')
+# a.list_loaded_modules()
 # {'writer': [<dsi.plugins.env.Hostname object at 0x7f21232474d0>],
 #  'reader': [<dsi.plugins.env.Bueno object at 0x7f2123247410>],
 #  'front-end': [],
 #   'back-end': []}
+
+
+# Example use
+# a.load_module('plugin','Bueno','reader',filenames='data/bueno1.data')
+# a.load_module('backend','Sqlite','back-end',filename='data/bueno.db')
+# a.transload()
+# a.artifact_handler(interaction_type='put')
+# a.artifact_handler(interaction_type='get', query = "SELECT * FROM sqlite_master WHERE type='table';", isVerbose = True)

--- a/examples/data/schema2.toml
+++ b/examples/data/schema2.toml
@@ -1,28 +1,28 @@
-[math2]
+[math]
 specification = "!jack"
-a = 1
+a = 2
 b = "there is CM"
 c = ["45.98", "cm"]
-d = 2
-e = 34.8
-f = 89.0e-4
+d = 3
+e = 35.8
+f = 869.0e-4
 
-[address2]
+[address]
 specification = "!sam"
 fileLoc = '/home/sam/lib/data'
 g = "good memories"
 h = "556place street"
-i = 2
-j = 3 
-k = 4
-l = 10000.0e-4
-m = 99
+i = 3
+j = 4 
+k = 5
+l = 110000.0e-4
+m = 999
 
-[physics2]
+[physics]
 specification = "!amy"
-n = ["9.8", "m / s / s"]
+n = ["19.8", "m / s / s"]
 o = "gravity"
-p = ["23", "s"]
+p = ["24", "s"]
 q = "home 23"
-r = ['1', 'million grams']
-s = -12.0e-4
+r = ['2', 'million grams']
+s = -122.0e-4

--- a/examples/data/schema2.yml
+++ b/examples/data/schema2.yml
@@ -1,29 +1,29 @@
 ---
-segment: math2
+segment: math
 specification: !jack
-  a: 1
+  a: 2
   b: "there is CM"
   c: "45.98 cm"
-  d: 2
-  e: 34.8
-  f: 89.0e-4
+  d: 3
+  e: 44.8
+  f: 99.0e-4
 ---
-segment: address2
+segment: address
 specification: !sam
   fileLoc: '/home/sam/lib/data'
   g: "good memories"
   h: "556place street"
-  i: 2
-  j: 3 
-  k: 4
-  l: 10000.0e-4
-  m: 99
+  i: 3
+  j: 4 
+  k: 5
+  l: 110000.0e-4
+  m: 999
 ---
-segment: physics2
+segment: physics
 specification: !amy
-  n: "9.8 m / s / s"
+  n: "91.8 m / s / s"
   o: "gravity"
-  p: "23 s"
+  p: "233 s"
   q: "home 23"
-  r: '1 million grams'
-  s: -12.0e-4
+  r: '12 million grams'
+  s: -122.0e-4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pyarrow>=12.0.1
 pydantic>=2.1.1
 nbconvert>=7.13.0
 gitpython>=3.0.0
+matplotlib>=3.6.0
+pyyaml>=6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ nbconvert>=7.13.0
 gitpython>=3.0.0
 matplotlib>=3.6.0
 pyyaml>=6.0
+toml>=0.10.2


### PR DESCRIPTION
Changed internal data abstraction (ordered dictionary) into nested ordered dictionaries so it can handle multiple tables ingested - each table is its own ordered dictionary.

Updated metadata.py to handle the extra level of collections (the internal data abstraction)
Updated sqlite.py to loop through all tables to create them
Updated core.py to allow these new plugins to be loaded and separated the use of readers/writers in transload()

Added yaml/toml file readers and table_plot file writer in format used by core terminal.
  - readers use add_rows() and writers use get_rows() which inputs the collection to be formatted for a file output

Edited coreterminal.py with 2 workflows on loading readers, writers and a backend (sqlite)

Added capability to store table relations through PK/FK columns
Updated sqlite.py to handle these relations