### PR TITLE
federation and user examples changes

### DIFF
--- a/dsi/backends/oceans11.py
+++ b/dsi/backends/oceans11.py
@@ -85,7 +85,7 @@ class Oceans11(Webserver):
         DEFAULT_URL = "https://oceans11.lanl.gov/dataCatalog/oceans11.db"
         base_url = url or DEFAULT_URL
 
-       # ----------------------------------------------------------------------
+        # ----------------------------------------------------------------------
         # Auth / connection config
         # ----------------------------------------------------------------------
         self.workspace = kwargs.get(
@@ -98,6 +98,10 @@ class Oceans11(Webserver):
             raise ValueError("Oceans11 catalog URL must be http or https")
 
         self.base_url = base_url.rstrip("/")
+
+        # skip data retrieval if only checking connection to oceans11
+        if kwargs.get("only_validate", False):
+            return
 
         # Data storage (tiered structure)
         # Tier 1: datasets, Tier 2: per-dataset resource tables
@@ -131,7 +135,7 @@ class Oceans11(Webserver):
     # ----------------------------------------------------------------------
     # Connection Validation
     # ----------------------------------------------------------------------
-    def validate_connection(self):
+    def validate_connection(self, **kwargs):
         """
         Validates that the base Oceans11 URL is accessible and functional.
         
@@ -162,15 +166,27 @@ class Oceans11(Webserver):
                 )
 
             if info is None:
+                if kwargs.get("only_validate", False):
+                    return False
                 raise ConnectionError(f"Failed to download catalog from {self.base_url}")
 
             local_path = info.get("local_path")
             if not local_path or not Path(local_path).is_file():
+                if kwargs.get("only_validate", False):
+                    return False
                 raise RuntimeError("Downloaded catalog file is invalid or missing")
+
+            # skip data retrieval if only checking connection to oceans11
+            if kwargs.get("only_validate", False):
+                import shutil
+                shutil.rmtree(info["folder_hash"] + "/")
+                return True
 
             return local_path
 
         except Exception as e:
+            if kwargs.get("only_validate", False):
+                return False
             raise ConnectionError(f"Unable to access Oceans11 catalog: {e}") from e
 
     # ---------------------------------------------------

--- a/dsi/dsi.py
+++ b/dsi/dsi.py
@@ -220,8 +220,8 @@ class DSI():
         n = OSTI()
         if n.validate_connection():
             print("OSTI : Read-only data catalog backend for discovering and querying OSTI (REST-based) open data resources.")
-        n = Oceans11()
-        if n.validate_connection():
+        n = Oceans11(only_validate=True)
+        if n.validate_connection(only_validate=True):
             print("Oceans11 : Read-only data catalog backend for discovering and querying Oceans11 (DSI-based) open data resources.")
         print()
 

--- a/dsi/sync.py
+++ b/dsi/sync.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Iterator
 from contextlib import redirect_stdout
 from collections import OrderedDict
+from urllib.parse import urlparse
 
 from dsi.core import Terminal
 from dsi.utils.federated.federate_datasets import federate_datasets, pull_data
@@ -787,13 +788,31 @@ class Sync():
         
         # add unique hash to download data
         workspace_folder = os.path.join(workspace_folder, db_data["folder_hash"])
-        
-        # Currently pulling all data referenced -- eventually allow user to download certain data
-        db_info, username = pull_data(db_data["location_type"], db_data["location"], remote_loc, 
-                                      workspace_folder, username, internal_use=True)
-        new_folder = Path(db_info.pop("new_db_folder"))
-        if new_folder.is_dir() and not any(new_folder.iterdir()):
-            new_folder.rmdir()
+
+        # if data files are URLs, then download them from filesystem, not using federated
+        def is_url(s):
+            try:
+                result = urlparse(s)
+                return all([result.scheme, result.netloc])
+            except Exception:
+                return False
+
+        if is_url(remote_loc):
+            remote_files = t2.get_table("filesystem")["file_remote"]
+            for remote_url in remote_files:
+                # Downloading each file from fileystem
+                db_info, username = pull_data(db_data["location_type"], db_data["location"], remote_url, 
+                                            workspace_folder, username, internal_use=True)
+                new_folder = Path(db_info.pop("new_db_folder"))
+                if new_folder.is_dir() and not any(new_folder.iterdir()):
+                    new_folder.rmdir()
+        else:        
+            # Currently pulling all referenced data -- eventually allow user to download certain data
+            db_info, username = pull_data(db_data["location_type"], db_data["location"], remote_loc, 
+                                        workspace_folder, username, internal_use=True)
+            new_folder = Path(db_info.pop("new_db_folder"))
+            if new_folder.is_dir() and not any(new_folder.iterdir()):
+                new_folder.rmdir()
 
 
     def gen_uuid(self, st):

--- a/dsi/sync.py
+++ b/dsi/sync.py
@@ -799,10 +799,11 @@ class Sync():
 
         if is_url(remote_loc):
             remote_files = t2.get_table("filesystem")["file_remote"]
+            parent_url = os.path.commonprefix(remote_files.tolist())
             for remote_url in remote_files:
                 # Downloading each file from fileystem
                 db_info, username = pull_data(db_data["location_type"], db_data["location"], remote_url, 
-                                            workspace_folder, username, internal_use=True)
+                                            workspace_folder, username, internal_use=True, parent_hash=parent_url)
                 new_folder = Path(db_info.pop("new_db_folder"))
                 if new_folder.is_dir() and not any(new_folder.iterdir()):
                     new_folder.rmdir()

--- a/dsi/utils/federated/federate_datasets.py
+++ b/dsi/utils/federated/federate_datasets.py
@@ -79,7 +79,8 @@ def pull_data(location_type: str,
               abs_path_workspace_folder: str, 
               username: str,
               download_limit: int = 10485760,
-              internal_use = False) -> dict | tuple[dict | None, str]:
+              internal_use = False,
+              parent_hash: str = None) -> dict | tuple[dict | None, str]:
     """Pulls data from a specified location based on the location type (e.g., "github", "HPC", "HPC-Kerberos", "URL", "local"). 
     The function checks for existing files, compares them with remote versions using MD5 checksums, and downloads or skips files accordingly. 
     It also handles user interactions for confirming downloads of large files and manages host usernames for HPC access.
@@ -100,8 +101,11 @@ def pull_data(location_type: str,
     filename = get_last_part(path)
 
     # Create folder for data
-    abs_path_workspace_folder = str(Path(abs_path_workspace_folder).resolve()) 
-    folder_hash, abs_path_db_folder = create_folder_from_path(location, abs_path_workspace_folder)  
+    abs_path_workspace_folder = str(Path(abs_path_workspace_folder).resolve())
+    if parent_hash:
+        folder_hash, abs_path_db_folder = create_folder_from_path(parent_hash, abs_path_workspace_folder)
+    else:
+        folder_hash, abs_path_db_folder = create_folder_from_path(path, abs_path_workspace_folder)
 
     # Get the absolute path to the file to be downloaded
     file_path = Path(abs_path_db_folder) / filename

--- a/examples/federated/local_dsi_sources.csv
+++ b/examples/federated/local_dsi_sources.csv
@@ -3,5 +3,5 @@ local,local,../federated/database/ocean_11_datasets.db,data,pascal grosset,pasca
 HPC,ch-fe.lanl.gov,/lustre/scratch5/pascalgrosset/test_db/nif.db,data,pascal grosset,pascalgrosset@lanl.gov,2026-3-10--16:38:00
 url,url,https://www.timestored.com/data/sample/sakila.db,data,unknown,unknown,2026-3-10--16:38:00
 HPC,darwin-fe.lanl.gov,/users/pulido/modelcard2.db,model,pascal grosset,pascalgrosset@lanl.gov,2026-2-10--16:42:00
-github,github,https://github.com/lanl/dsi/tree/ai_dev/tools/ai_search/data/oceans_11/ocean_11_datasets.db,data,pascal grosset,pascalgrosset@lanl.gov,2026-2-10--16:30:00
+url,url,https://oceans11.lanl.gov/dataCatalog/oceans11.db,data,pascal grosset,pascalgrosset@lanl.gov,2026-2-10--16:30:00
 HPC,darwin-fe.lanl.gov,/vast/projects/exasky/pascal/genesis_model_cards/modelcard.db,model,pascal grosset,pascalgrosset@lanl.gov,2026-2-10--16:40:00s

--- a/examples/user/11.get.py
+++ b/examples/user/11.get.py
@@ -10,7 +10,7 @@ s = Sync("federated.db")
 s.get(config_file=remote_sources, workspace_folder=workspace)
 
 # Download data referenced in this database -- db must have been previously indexed by DSI
-s.get_data(db_name="ocean_11_datasets.db", workspace_folder=workspace)
+s.get_data(db_name="oceans11.db", workspace_folder=workspace)
 
 
 from dsi.dsifederated import DSIFederated

--- a/examples/user/3.visualize.py
+++ b/examples/user/3.visualize.py
@@ -1,7 +1,7 @@
 # examples/user/3.visualize.py
 from dsi.dsi import DSI
 
-visual_dsi = DSI("data.db") # Assuming data.db has data from 2a.read.py:
+visual_dsi = DSI("clover3d.db") # Assuming data.db has data from 2a.read.py:
 
 visual_dsi.num_tables()
 visual_dsi.list()

--- a/examples/user/4.find.py
+++ b/examples/user/4.find.py
@@ -1,7 +1,7 @@
 # examples/user/4.find.py
 from dsi.dsi import DSI
 
-find_dsi = DSI("data.db") # Assuming data.db has data from 2a.read.py:
+find_dsi = DSI("clover3d.db") # Assuming data.db has data from 2a.read.py:
 
 #dsi.search(value)
 find_dsi.search("Jun 2025") # searches for the value 'Jun 2025' in all tables

--- a/examples/user/5.update.py
+++ b/examples/user/5.update.py
@@ -1,7 +1,7 @@
 # examples/user/5.update.py
 from dsi.dsi import DSI
 
-update_dsi = DSI("data.db") # Assuming data.db has data from 2a.read.py:
+update_dsi = DSI("clover3d.db") # Assuming data.db has data from 2a.read.py:
 
 #dsi.find(condition, collection)
 find_df = update_dsi.find("state2_density > 5.0", True, True) # Returns matching rows as a DataFrame

--- a/examples/user/6.query.py
+++ b/examples/user/6.query.py
@@ -1,7 +1,7 @@
 # examples/user/6.query.py
 from dsi.dsi import DSI
 
-query_dsi = DSI("data.db") # Assuming data.db has data from 2a.read.py:
+query_dsi = DSI("clover3d.db") # Assuming data.db has data from 2a.read.py:
 
 #dsi.query(sql_statement)
 query_dsi.query("SELECT * FROM input")


### PR DESCRIPTION
- get_data with url is now updated to download all data in one folder, not separate folders for each url data file
- user examples updated with correct referenced db name
- oceans11 backend doesn't download data when calling list_backends() -- just validate connection
- federated example uses updated oceans11 db that is on oceans11.lanl.gov (all changes work on dsi side)