### PR TITLE
Correct optional S3 dependency guard

### DIFF
--- a/dsi/tests/test_s3_utils.py
+++ b/dsi/tests/test_s3_utils.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class TestS3OptionalDependency(unittest.TestCase):
+    def test_s3_module_imports_without_boto3(self):
+        script = textwrap.dedent(
+            """
+            import builtins
+
+            real_import = builtins.__import__
+
+            def block_boto3(name, *args, **kwargs):
+                if name == "boto3" or name.startswith("botocore"):
+                    raise ModuleNotFoundError(name)
+                return real_import(name, *args, **kwargs)
+
+            builtins.__import__ = block_boto3
+            from dsi.utils.s3_utils import get_s3_client
+
+            try:
+                get_s3_client(interactive=False)
+            except ImportError as exc:
+                assert "boto3" in str(exc)
+            else:
+                raise AssertionError("missing boto3 was not reported")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path(__file__).parents[2],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)

--- a/dsi/tests/test_s3_utils.py
+++ b/dsi/tests/test_s3_utils.py
@@ -9,16 +9,9 @@ class TestS3OptionalDependency(unittest.TestCase):
     def test_s3_module_imports_without_boto3(self):
         script = textwrap.dedent(
             """
-            import builtins
+            import sys
 
-            real_import = builtins.__import__
-
-            def block_boto3(name, *args, **kwargs):
-                if name == "boto3" or name.startswith("botocore"):
-                    raise ModuleNotFoundError(name)
-                return real_import(name, *args, **kwargs)
-
-            builtins.__import__ = block_boto3
+            sys.modules["boto3"] = sys.modules["botocore"] = None
             from dsi.utils.s3_utils import get_s3_client
 
             try:

--- a/dsi/utils/s3_utils.py
+++ b/dsi/utils/s3_utils.py
@@ -2,9 +2,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 import getpass
 import os
-import importlib.util
 
-if importlib.util.find_spec("duckdb") is not None:
+try:
     import boto3
     from botocore import UNSIGNED
     from botocore.config import Config
@@ -14,6 +13,11 @@ if importlib.util.find_spec("duckdb") is not None:
         NoCredentialsError,
         PartialCredentialsError,
     )
+except ModuleNotFoundError:
+    boto3 = None
+    UNSIGNED = Config = None
+    BotoCoreError = ClientError = ImportError
+    NoCredentialsError = PartialCredentialsError = ImportError
 
 
 def get_s3_client(
@@ -43,6 +47,9 @@ def get_s3_client(
     Returns:
         boto3 S3 client
     """
+    if boto3 is None:
+        raise ImportError("S3 support requires the optional boto3 dependency.")
+
     region = (
         region_name
         or os.environ.get("AWS_DEFAULT_REGION")


### PR DESCRIPTION
## Summary

Guard S3 imports with `boto3`, not `duckdb`. Raise a clear error when S3 is used without the optional dependency.

## Validation

- `pytest dsi/tests/test_s3_utils.py -q`
- `ruff check dsi/ --ignore E402,E701`
- `codespell dsi/utils/s3_utils.py dsi/tests/test_s3_utils.py`
- `compileall -q dsi`
- Full Windows suite: 140 passed, 43 failures outside this diff: GUFI/HPSS, stale core/env plugin tests, SQLAlchemy fixture reuse, Graphviz, and database file locks.